### PR TITLE
Updated menu highlight geometry for macOS 26

### DIFF
--- a/Sources/MacControlCenterUI/Menu Abstracts/HighlightingMenuItem.swift
+++ b/Sources/MacControlCenterUI/Menu Abstracts/HighlightingMenuItem.swift
@@ -117,7 +117,11 @@ public struct HighlightingMenuItem<Content: View>: View, MacControlCenterMenuIte
     // MARK: Helpers
     
     private var backgroundShape: some Shape {
-        RoundedRectangle(cornerSize: .init(width: 5, height: 5))
+        if #available(macOS 26, *) {
+            RoundedRectangle(cornerSize: .init(width: 10, height: 10), style: .continuous)
+        } else {
+            RoundedRectangle(cornerSize: .init(width: 5, height: 5))
+        }
     }
     
     private var visualEffect: VisualEffect? {

--- a/Sources/MacControlCenterUI/Menu Internal/Menu Constants.swift
+++ b/Sources/MacControlCenterUI/Menu Internal/Menu Constants.swift
@@ -14,7 +14,15 @@ enum MenuGeometry {
     static let menuItemStandardHoverBackColor = Color(NSColor.selectedContentBackgroundColor)
     
     static let menuHorizontalContentInset: CGFloat = 14
-    static let menuHorizontalHighlightInset: CGFloat = 4
+
+    static var menuHorizontalHighlightInset: CGFloat {
+        if #available(macOS 26, *) {
+            return 6
+        } else {
+            return 4
+        }
+    }
+
     static let menuVerticalPadding: CGFloat = 1
     static let menuItemPadding: CGFloat = 4
     static let menuItemContentStandardHeight: CGFloat = 18


### PR DESCRIPTION
This pull request introduces minor improvements to the menu item appearance in macOS Control Center UI, specifically adjusting highlight visuals for macOS 26 (Tahoe) and newer. The changes ensure a more modern look on newer macOS versions while maintaining compatibility with older ones.

Visual enhancements for macOS 26+:

* Updated the `backgroundShape` in `HighlightingMenuItem` to use a larger, continuous rounded rectangle on macOS 26 and newer, improving the highlight effect.
* Changed `menuHorizontalHighlightInset` in `MenuGeometry` to dynamically use a wider inset (6 points) on macOS 26+, and keep the previous value (4 points) on older versions, for better spacing consistency.

<img width="332" height="73" alt="Screenshot 2026-01-16 at 9 31 40 PM" src="https://github.com/user-attachments/assets/5c7a35e1-5768-45fb-8b7d-248396488700" />